### PR TITLE
Don't count todo list generator failures as errors

### DIFF
--- a/.github/workflows/KiARC Repository Manager.yml
+++ b/.github/workflows/KiARC Repository Manager.yml
@@ -6,7 +6,6 @@ jobs:
   format-code:
     name: Format Code
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - uses: axel-op/googlejavaformat-action@v3
@@ -17,6 +16,7 @@ jobs:
   generate-todo-list:
     name: ToDo List Generator
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - name: Generate List

--- a/todolist.txt
+++ b/todolist.txt
@@ -11,8 +11,8 @@ src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 145: 0.102, 5.66, 0.306
 src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 150: 0.165, 2.01, 0.155)) // TODO characterize
 src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 159: 0.61755, // TODO measure the distance from one side of the drive to the other
 src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 165: // TODO setup elevator, with Meters
-src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 185: elevatorPulleyMotor.setPID(0, 0, 0); // TODO tune pid
-src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 251: 0, // TODO tune pid
+src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 186: elevatorPulleyMotor.setPID(0, 0, 0); // TODO tune pid
+src/main/java/frc/team449/javaMaps/Bunnybot2021Map.java: 252: 0, // TODO tune pid
 src/main/java/frc/team449/javaMaps/PositionControlTest.java: 43: // TODO Declare these constants outside this method and remove unused variables
 src/main/java/frc/team449/javaMaps/PositionControlTest.java: 64: driverIntakeOff = 2, // TODO This is never used
 src/main/java/frc/team449/javaMaps/PositionControlTest.java: 65: driverIntakeRev = 3, // TODO This is never used


### PR DESCRIPTION
When merging, the todo list generator fails because it can't push. This is a minor fix to let Github know our build isn't failing.